### PR TITLE
Replace std::regex with fnmatch()/PathMatchSpec as a workaround to std::regex stack overflow known bug 

### DIFF
--- a/Tensile/Source/lib/CMakeLists.txt
+++ b/Tensile/Source/lib/CMakeLists.txt
@@ -143,6 +143,7 @@ if(TENSILE_USE_HIP)
 
     if(WIN32)
         target_compile_options( TensileHost PUBLIC -Wno-deprecated-declarations -Wno-ignored-attributes -Wdll-attribute-on-redeclaration -fdelayed-template-parsing )
+        target_link_libraries( TensileHost PUBLIC Shlwapi )
     endif()
 endif()
 

--- a/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
@@ -67,45 +67,45 @@ namespace Tensile
         switch(condition)
         {
         case LazyLoadingInit::All:
-            return "TensileLibrary_.*";
+            return "TensileLibrary_*";
         case LazyLoadingInit::gfx803:
-            return "TensileLibrary_*_gfx803.*";
+            return "TensileLibrary_*_gfx803";
         case LazyLoadingInit::gfx900:
-            return "TensileLibrary_*_gfx900.*";
+            return "TensileLibrary_*_gfx900";
         case LazyLoadingInit::gfx906:
-            return "TensileLibrary_*_gfx906.*";
+            return "TensileLibrary_*_gfx906";
         case LazyLoadingInit::gfx908:
-            return "TensileLibrary_*_gfx908.*";
+            return "TensileLibrary_*_gfx908";
         case LazyLoadingInit::gfx90a:
-            return "TensileLibrary_*_gfx90a.*";
+            return "TensileLibrary_*_gfx90a";
         case LazyLoadingInit::gfx940:
-            return "TensileLibrary_*_gfx940.*";
+            return "TensileLibrary_*_gfx940";
         case LazyLoadingInit::gfx941:
-            return "TensileLibrary_*_gfx941.*";
+            return "TensileLibrary_*_gfx941";
         case LazyLoadingInit::gfx942:
-            return "TensileLibrary_*_gfx942.*";
+            return "TensileLibrary_*_gfx942";
         case LazyLoadingInit::gfx1010:
-            return "TensileLibrary_*_gfx1010.*";
+            return "TensileLibrary_*_gfx1010";
         case LazyLoadingInit::gfx1011:
-            return "TensileLibrary_*_gfx1011.*";
+            return "TensileLibrary_*_gfx1011";
         case LazyLoadingInit::gfx1012:
-            return "TensileLibrary_*_gfx1012.*";
+            return "TensileLibrary_*_gfx1012";
         case LazyLoadingInit::gfx1030:
-            return "TensileLibrary_*_gfx1030.*";
+            return "TensileLibrary_*_gfx1030";
         case LazyLoadingInit::gfx1031:
-            return "TensileLibrary_*_gfx1031.*";
+            return "TensileLibrary_*_gfx1031";
         case LazyLoadingInit::gfx1032:
-            return "TensileLibrary_*_gfx1032.*";
+            return "TensileLibrary_*_gfx1032";
         case LazyLoadingInit::gfx1034:
-            return "TensileLibrary_*_gfx1034.*";
+            return "TensileLibrary_*_gfx1034";
         case LazyLoadingInit::gfx1035:
-            return "TensileLibrary_*_gfx1035.*";
+            return "TensileLibrary_*_gfx1035";
         case LazyLoadingInit::gfx1100:
-            return "TensileLibrary_*_gfx1100.*";
+            return "TensileLibrary_*_gfx1100";
         case LazyLoadingInit::gfx1101:
-            return "TensileLibrary_*_gfx1101.*";
+            return "TensileLibrary_*_gfx1101";
         case LazyLoadingInit::gfx1102:
-            return "TensileLibrary_*_gfx1102.*";
+            return "TensileLibrary_*_gfx1102";
         case LazyLoadingInit::None:
             return "";
         }

--- a/Tensile/Source/lib/include/Tensile/Serialization/PlaceholderLibrary.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/PlaceholderLibrary.hpp
@@ -31,7 +31,12 @@
 
 #include <Tensile/MasterSolutionLibrary.hpp>
 #include <Tensile/PlaceholderLibrary.hpp>
-#include <regex>
+//Replace std::regex, as it crashes when matching long lines(GCC Bug #86164).
+#ifdef WIN32
+#include "shlwapi.h"
+#else
+#include <fnmatch.h>
+#endif
 
 namespace Tensile
 {
@@ -68,7 +73,11 @@ namespace Tensile
                     for(auto condition : ctx->preloaded)
                     {
                         std::string pattern = RegexPattern(condition);
-                        if(std::regex_search(lib.filePrefix, std::regex(pattern)))
+#ifdef WIN32
+                        if(PathMatchSpecA(lib.filePrefix.c_str(), pattern.c_str()))
+#else
+                        if(fnmatch(pattern.c_str(), lib.filePrefix.c_str(), 0) == 0)
+#endif
                         {
                             lib.loadPlaceholderLibrary();
                             break;


### PR DESCRIPTION
Replace std::regex with fnmatch()/PathMatchSpec as a workaround to std::regex stack overflow known bug 